### PR TITLE
Build gRPC clients and servers Rust code from protobuf

### DIFF
--- a/.github/workflows/check-buf.yaml
+++ b/.github/workflows/check-buf.yaml
@@ -1,4 +1,4 @@
-name: workflow-for-pull-request
+name: check protobuf
 on: pull_request
 jobs:
   check:
@@ -16,7 +16,7 @@ jobs:
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
       - uses: bufbuild/buf-setup-action@v1
       - uses: bufbuild/buf-lint-action@v1
-      - name: Format all Protobuf files
+      - name: Format all protobuf files
         run: |
           buf format --write
           if git diff --exit-code --quiet; then
@@ -25,9 +25,9 @@ jobs:
           git config user.name 'github-actions'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add --all
-          git commit -m "Format all Protobuf files"
+          git commit -m "Format all protobuf files"
           git push origin @
-      - name: Generate code from all Protobuf files
+      - name: Generate code from all protobuf files
         run: |
           buf generate
           if git diff --exit-code --quiet; then
@@ -36,10 +36,8 @@ jobs:
           git config user.name 'github-actions'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add --all
-          git commit -m "Generate code from all Protobuf files"
+          git commit -m "Generate code from all protobuf files"
           git push origin @
-      - name: Commit, add and push all diff files
-        run: |
       - uses: bufbuild/buf-breaking-action@v1
         with:
           against: 'https://github.com/${GITHUB_REPOSITORY}.git#branch=main'

--- a/.github/workflows/check-buf.yaml
+++ b/.github/workflows/check-buf.yaml
@@ -1,7 +1,7 @@
 name: check protobuf
 on: pull_request
 jobs:
-  check:
+  check-buf:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
           git config user.name 'github-actions'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add --all
-          git commit -m "Format all protobuf files"
+          git commit -m "Run buf format"
           git push origin @
       - name: Generate code from all protobuf files
         run: |
@@ -36,7 +36,7 @@ jobs:
           git config user.name 'github-actions'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add --all
-          git commit -m "Generate code from all protobuf files"
+          git commit -m "Run buf generate"
           git push origin @
       - uses: bufbuild/buf-breaking-action@v1
         with:

--- a/.github/workflows/check-rust.yaml
+++ b/.github/workflows/check-rust.yaml
@@ -1,0 +1,32 @@
+name: check rust code
+on: pull_request
+jobs:
+  check-rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: arduino/setup-protoc@v1
+      - uses: Swatinem/rust-cache@v2
+      - name: Run cargo clippy
+        run: |
+          cargo_toml_path=$(find . -name 'Cargo.toml')
+          cargo clippy --manifest-path "$cargo_toml_path" --bins --tests --examples --all -- -D warnings
+      - name: Commit, add and push codes
+        run: |
+          cargo_toml_path=$(find . -name 'Cargo.toml')
+          cargo fmt --manifest-path "$cargo_toml_path"
+          if git diff --exit-code --quiet; then
+            exit 0
+          fi
+          git config user.name 'github-actions'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add --all
+          git commit -m "Run rustfmt"
+          git push origin @
+      - name: Compile packages
+        run: |
+          cargo_toml_path=$(find . -name 'Cargo.toml')
+          cargo build --manifest-path "$cargo_toml_path"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/gen/rust/target
+/gen/rust/Cargo.lock

--- a/gen/rust/Cargo.toml
+++ b/gen/rust/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "xoon-proto-gen-rust"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/gen/rust/Cargo.toml
+++ b/gen/rust/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+prost = "0.11.0"
+prost-types = "0.11.1"
+tonic = "0.8.1"
+
+[build-dependencies]
+tonic-build = "0.8.0"

--- a/gen/rust/build.rs
+++ b/gen/rust/build.rs
@@ -1,0 +1,36 @@
+const PROTO_ROOT_DIR: &str = "../../proto";
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR")?);
+    tonic_build::configure()
+        .file_descriptor_set_path(out_dir.join("kintai_service_descriptor.bin"))
+        .compile(
+            &[format!("{PROTO_ROOT_DIR}/kintai/v1/kintai_service.proto")],
+            &[PROTO_ROOT_DIR],
+        )?;
+    tonic_build::configure()
+        .file_descriptor_set_path(out_dir.join("notification_service_descriptor.bin"))
+        .compile(
+            &[format!(
+                "{PROTO_ROOT_DIR}/notification/v1/notification_service.proto"
+            )],
+            &[PROTO_ROOT_DIR],
+        )?;
+    tonic_build::configure()
+        .file_descriptor_set_path(out_dir.join("release_service_descriptor.bin"))
+        .compile(
+            &[format!(
+                "{PROTO_ROOT_DIR}/automation/v1/release_service.proto"
+            )],
+            &[PROTO_ROOT_DIR],
+        )?;
+    tonic_build::configure()
+        .file_descriptor_set_path(out_dir.join("server_status_service_descriptor.bin"))
+        .compile(
+            &[format!(
+                "{PROTO_ROOT_DIR}/server_status/v1/server_status_service.proto"
+            )],
+            &[PROTO_ROOT_DIR],
+        )?;
+    Ok(())
+}

--- a/gen/rust/src/lib.rs
+++ b/gen/rust/src/lib.rs
@@ -1,0 +1,36 @@
+// tonic does not derive `Eq` for the gRPC message types, which causes a warning from Clippy. The
+// current suggestion is to explicitly allow the lint in the module that imports the protos.
+// Read more: https://github.com/hyperium/tonic/issues/1056
+#![allow(clippy::derive_partial_eq_without_eq)]
+
+pub mod kintai {
+    pub mod v1 {
+        tonic::include_proto!("kintai.v1");
+        pub const KINTAI_SERVICE_FILE_DESCRIPTOR_SET: &[u8] =
+            tonic::include_file_descriptor_set!("kintai_service_descriptor");
+    }
+}
+
+pub mod notification {
+    pub mod v1 {
+        tonic::include_proto!("notification.v1");
+        pub const NOTIFICATION_SERVICE_FILE_DESCRIPTOR_SET: &[u8] =
+            tonic::include_file_descriptor_set!("notification_service_descriptor");
+    }
+}
+
+pub mod automation {
+    pub mod v1 {
+        tonic::include_proto!("automation.v1");
+        pub const RELEASE_SERVICE_FILE_DESCRIPTOR_SET: &[u8] =
+            tonic::include_file_descriptor_set!("release_service_descriptor");
+    }
+}
+
+pub mod server_status {
+    pub mod v1 {
+        tonic::include_proto!("server_status.v1");
+        pub const SERVER_STATUS_SERVICE_DESCRIPTOR_SET: &[u8] =
+            tonic::include_file_descriptor_set!("server_status_service_descriptor");
+    }
+}

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -1,8 +1,14 @@
-#!/bin/sh
+#!/bin/sh -eu
 
+# For protobuf
 buf lint
 result=0; buf format --diff --exit-code proto || result=$?
 if [ "$result" != 0 ]; then
   exit 1
 fi
 buf generate proto
+
+# For Rust
+cargo_toml_path=$(find . -name 'Cargo.toml')
+cargo clippy --manifest-path "$cargo_toml_path" --bins --tests --examples --all -- -D warnings
+cargo fmt --manifest-path "$cargo_toml_path" --check

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -2,11 +2,8 @@
 
 # For protobuf
 buf lint
-result=0; buf format --diff --exit-code proto || result=$?
-if [ "$result" != 0 ]; then
-  exit 1
-fi
-buf generate proto
+buf format --diff --exit-code
+buf generate
 
 # For Rust
 cargo_toml_path=$(find . -name 'Cargo.toml')


### PR DESCRIPTION
# Overview

[xoon-proto-gen-rust](https://github.com/pyama2000/xoon-proto-gen-rust)でprotobufからRustのコード生成をしていたが[The Book](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-other-registries)によるとrootになくてもCargo.tomlを再帰的に見つけてくれるので、このリポジトリでコード生成した

close #27 