### PR TITLE
Build Rust code from protobuf with `--experimental_allow_proto3_optional` arg

### DIFF
--- a/gen/rust/build.rs
+++ b/gen/rust/build.rs
@@ -3,12 +3,14 @@ const PROTO_ROOT_DIR: &str = "../../proto";
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR")?);
     tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
         .file_descriptor_set_path(out_dir.join("kintai_service_descriptor.bin"))
         .compile(
             &[format!("{PROTO_ROOT_DIR}/kintai/v1/kintai_service.proto")],
             &[PROTO_ROOT_DIR],
         )?;
     tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
         .file_descriptor_set_path(out_dir.join("notification_service_descriptor.bin"))
         .compile(
             &[format!(
@@ -17,6 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &[PROTO_ROOT_DIR],
         )?;
     tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
         .file_descriptor_set_path(out_dir.join("release_service_descriptor.bin"))
         .compile(
             &[format!(
@@ -25,6 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &[PROTO_ROOT_DIR],
         )?;
     tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
         .file_descriptor_set_path(out_dir.join("server_status_service_descriptor.bin"))
         .compile(
             &[format!(


### PR DESCRIPTION
# Overview

Add [protoc_arg](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.protoc_arg) when building Rust code
